### PR TITLE
Use AES-CTR rather than AES-GCM. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,8 +50,8 @@ function encryptAttachment(plaintextBuffer) {
  * Decrypt an attachment.
  * @param {ArrayBuffer} ciphertextBuffer The encrypted attachment data buffer.
  * @param {Object} info The information needed to decrypt the attachment.
- * @param {Object} info.key AES-GCM JWK key object.
- * @param {string} info.iv Base64 encoded AES-GCM IV.
+ * @param {Object} info.key AES-CTR JWK key object.
+ * @param {string} info.iv Base64 encoded 16 byte AES-CTR IV.
  * @param {string} info.hashes.sha256 Base64 encoded SHA-256 hash of the ciphertext.
  * @return {Promise} A promise that resolves with an ArrayBuffer when the attachment is decrypted.
  */

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function encryptAttachment(plaintextBuffer) {
     ivArray = window.crypto.getRandomValues(new Uint8Array(16));
     // Load the encryption key.
     return window.crypto.subtle.generateKey(
-        {"name": "AES-GCM", length:256}, true, ["encrypt", "decrypt"]
+        {"name": "AES-CTR", length:256}, true, ["encrypt", "decrypt"]
     ).then(function(generateKeyResult) {
         cryptoKey = generateKeyResult;
         // Export the Key as JWK.
@@ -24,7 +24,7 @@ function encryptAttachment(plaintextBuffer) {
         exportedKey = exportKeyResult;
         // Encrypt the input ArrayBuffer.
         return window.crypto.subtle.encrypt(
-            {name: "AES-GCM", iv: ivArray}, cryptoKey, plaintextBuffer
+            {name: "AES-CTR", counter: ivArray, length: 128}, cryptoKey, plaintextBuffer
         );
     }).then(function(encryptResult) {
         ciphertextBuffer = encryptResult;
@@ -67,7 +67,7 @@ function decryptAttachment(ciphertextBuffer, info) {
     var expectedSha256base64 = info.hashes.sha256;
     // Load the AES from the "key" key of the info object.
     return window.crypto.subtle.importKey(
-        "jwk", info.key, {"name": "AES-GCM"}, false, ["encrypt", "decrypt"]
+        "jwk", info.key, {"name": "AES-CTR"}, false, ["encrypt", "decrypt"]
     ).then(function (importKeyResult) {
         cryptoKey = importKeyResult;
         // Check the sha256 hash
@@ -77,7 +77,7 @@ function decryptAttachment(ciphertextBuffer, info) {
             throw new Error("Mismatched SHA-256 digest");
         }
         return window.crypto.subtle.decrypt(
-            {name: "AES-GCM", iv: ivArray}, cryptoKey, ciphertextBuffer
+            {name: "AES-CTR", counter: ivArray, length: 128}, cryptoKey, ciphertextBuffer
         );
     });
 }

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ function encryptAttachment(plaintextBuffer) {
     }).then(function(exportKeyResult) {
         exportedKey = exportKeyResult;
         // Encrypt the input ArrayBuffer.
+        // Use the entire iv as the counter by setting the "length" to 128.
         return window.crypto.subtle.encrypt(
             {name: "AES-CTR", counter: ivArray, length: 128}, cryptoKey, plaintextBuffer
         );
@@ -76,6 +77,7 @@ function decryptAttachment(ciphertextBuffer, info) {
         if (encodeBase64(new Uint8Array(digestResult)) != expectedSha256base64) {
             throw new Error("Mismatched SHA-256 digest");
         }
+        // Use the entire iv as the counter by setting the "length" to 128.
         return window.crypto.subtle.decrypt(
             {name: "AES-CTR", counter: ivArray, length: 128}, cryptoKey, ciphertextBuffer
         );

--- a/test/decrypt.Spec.js
+++ b/test/decrypt.Spec.js
@@ -21,7 +21,19 @@ describe("DecryptAttachment", function() {
                 "key_ops": ["encrypt", "decrypt"],
                 "kty": "oct"
             }, "iv": "/////////////////////w"
-        }, "SGVsbG8sIFdvcmxk"]
+        }, "SGVsbG8sIFdvcmxk"],
+        ["tJVNBVJ/vl36UQt4Y5e5myqUL3M8OtjRVQljZ+LlwbJeucRIM7CeKDJGGOjlJ1bqpqUdl6zytXJ3dCyvnUi4eQ", {
+            "hashes": {
+                "sha256": "/K4w3G4zlLK312k66KxNPKDkWCn2QAH5aphAkuncTrQ"
+            },
+            "key": {
+                "kty": "oct",
+                "key_ops": ["encrypt","decrypt"],
+                "k": "__________________________________________8",
+                "alg": "A256CTR"
+            },
+            "iv": "/////////////////////w"
+        }, "YWxwaGFudW1lcmljYWxseWFscGhhbnVtZXJpY2FsbHlhbHBoYW51bWVyaWNhbGx5YWxwaGFudW1lcmljYWxseQ"]
     ];
 
     testVectors.forEach(function (vector) {

--- a/test/decrypt.Spec.js
+++ b/test/decrypt.Spec.js
@@ -1,25 +1,27 @@
 describe("DecryptAttachment", function() {
     var testVectors = [
-        ["gxI1eiER6jOxtn6y/gX+hg", {
-            key: {
-                alg: "A256GCM",
-                k: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                kty: "oct",
-                key_ops: ["encrypt","decrypt"],
+        ["", {
+            "hashes": {
+                "sha256": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU"
             },
-            iv: "AAAAAAAAAAAAAAAAAAAAAA",
-            hashes: { sha256: "YhVyrkrEseY7Zu9Z/UolrKFbTkps0rSirf6MXspgwVo" },
+            "key": {
+                "alg": "A256CTR",
+                "k": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "key_ops": ["encrypt", "decrypt"],
+                "kty": "oct"
+            },
+            "iv": "AAAAAAAAAAAAAAAAAAAAAA"
         }, ""],
-        ["8cviqGwcc+gCiyV6Qwhcc43V/izXoHBKRH9vyw", {
-            iv: "/////////////////////w",
-            key: {
-                kty: "oct",
-                key_ops: ["encrypt", "decrypt" ],
-                k: "__________________________________________8",
-                alg: "A256GCM"
-            },
-            hashes: { sha256: "9vNkVndnOLSsQ5UvmKB/W5g/4ScVYHlSQS3QliU+Xvo" }
-        }, "SGVsbG8sIFdvcmxk"],
+        ["nZxRAVw962fwUQ5/", {
+            "hashes": {
+                "sha256": "geLWS2ptBew5aPLJRTK+QnI3Krdl3UaxN8qfahHWhfc"
+            }, "key": {
+                "alg": "A256CTR",
+                "k": "__________________________________________8",
+                "key_ops": ["encrypt", "decrypt"],
+                "kty": "oct"
+            }, "iv": "/////////////////////w"
+        }, "SGVsbG8sIFdvcmxk"]
     ];
 
     testVectors.forEach(function (vector) {

--- a/test/generate_test_vectors.py
+++ b/test/generate_test_vectors.py
@@ -46,4 +46,5 @@ def encrypt(key, iv, plaintext):
 json.dump([
     encrypt("\x00"*32, "\x00"*16, ""),
     encrypt("\xFF"*32, "\xFF"*16, "Hello, World"),
+    encrypt("\xFF"*32, "\xFF"*16, "alphanumerically" * 4),
 ], sys.stdout)

--- a/test/generate_test_vectors.py
+++ b/test/generate_test_vectors.py
@@ -25,17 +25,16 @@ b64u = lambda x: base64.urlsafe_b64encode(x).rstrip("=")
 def encrypt(key, iv, plaintext):
     encryptor = Cipher(
         algorithms.AES(key),
-        modes.GCM(iv),
+        modes.CTR(iv),
         backend=default_backend()
     ).encryptor()
 
     ciphertext = encryptor.update(plaintext) + encryptor.finalize()
-    ciphertext += encryptor.tag
 
     info = {
         "key": {
             "k": b64u(key),
-            "alg": "A256GCM",
+            "alg": "A256CTR",
             "kty": "oct",
             "key_ops": ["encrypt", "decrypt"],
         },


### PR DESCRIPTION
We already protect the integrity of the encrypted data using a SHA-256 of the encrypted content that's shipped alongside the decryption key.

This makes it easier to implement on iOS where apple won't let you access the
builtin AES-GCM implementation, but will let you use AES-CTR.

It's safe to use a stream cipher like AES-CTR here because we generate a new
key for attachment we encrypt.