### PR TITLE
Set the low 64 bits of the IV to zero.

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ function encryptAttachment(plaintextBuffer) {
     var sha256Buffer; // ArrayBuffer of digest.
     var ivArray; // Uint8Array of AES IV
     // Generate an IV where the first 8 bytes are random and the high 8 bytes
-    // are zero.
+    // are zero. We set the counter low bits to 0 since it makes it unlikely
+    // that the 64 bit counter will overflow.
     ivArray = new Uint8Array(16);
     window.crypto.getRandomValues(ivArray.subarray(0,8));
     // Load the encryption key.

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function encryptAttachment(plaintextBuffer) {
         // Encrypt the input ArrayBuffer.
         // Use half of the iv as the counter by setting the "length" to 64.
         return window.crypto.subtle.encrypt(
-            {name: "AES-CTR", counter: ivArray, length: 1}, cryptoKey, plaintextBuffer
+            {name: "AES-CTR", counter: ivArray, length: 64}, cryptoKey, plaintextBuffer
         );
     }).then(function(encryptResult) {
         ciphertextBuffer = encryptResult;

--- a/index.js
+++ b/index.js
@@ -11,11 +11,12 @@ function encryptAttachment(plaintextBuffer) {
     var ciphertextBuffer; // ArrayBuffer of encrypted data.
     var sha256Buffer; // ArrayBuffer of digest.
     var ivArray; // Uint8Array of AES IV
-    // Generate a random IV.
-    ivArray = window.crypto.getRandomValues(new Uint8Array(16));
+    // Generate an IV where the first 8 bytes are random.
+    ivArray = new Uint8Array(16);
+    window.crypto.getRandomValues(ivArray.subarray(0,8));
     // Load the encryption key.
     return window.crypto.subtle.generateKey(
-        {"name": "AES-CTR", length:256}, true, ["encrypt", "decrypt"]
+        {"name": "AES-CTR", length: 256}, true, ["encrypt", "decrypt"]
     ).then(function(generateKeyResult) {
         cryptoKey = generateKeyResult;
         // Export the Key as JWK.
@@ -25,7 +26,7 @@ function encryptAttachment(plaintextBuffer) {
         // Encrypt the input ArrayBuffer.
         // Use half of the iv as the counter by setting the "length" to 64.
         return window.crypto.subtle.encrypt(
-            {name: "AES-CTR", counter: ivArray, length: 64}, cryptoKey, plaintextBuffer
+            {name: "AES-CTR", counter: ivArray, length: 1}, cryptoKey, plaintextBuffer
         );
     }).then(function(encryptResult) {
         ciphertextBuffer = encryptResult;
@@ -37,7 +38,7 @@ function encryptAttachment(plaintextBuffer) {
         return {
             data: ciphertextBuffer,
             info: {
-                v: "v1",
+                v: "v2",
                 key: exportedKey,
                 iv: encodeBase64(ivArray),
                 hashes: {
@@ -79,8 +80,8 @@ function decryptAttachment(ciphertextBuffer, info) {
             throw new Error("Mismatched SHA-256 digest");
         }
         var counterLength;
-        if (info.v == "v1") {
-            // Version 1 uses a 64 bit counter.
+        if (info.v == "v1" || info.v == "v2") {
+            // Version 1 and 2 use a 64 bit counter.
             counterLength = 64;
         } else {
             // Version 0 uses a 128 bit counter.

--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ function encryptAttachment(plaintextBuffer) {
     var ciphertextBuffer; // ArrayBuffer of encrypted data.
     var sha256Buffer; // ArrayBuffer of digest.
     var ivArray; // Uint8Array of AES IV
-    // Generate an IV where the first 8 bytes are random.
+    // Generate an IV where the first 8 bytes are random and the high 8 bytes
+    // are zero.
     ivArray = new Uint8Array(16);
     window.crypto.getRandomValues(ivArray.subarray(0,8));
     // Load the encryption key.

--- a/test/decrypt.Spec.js
+++ b/test/decrypt.Spec.js
@@ -1,57 +1,109 @@
-describe("DecryptAttachment", function() {
-    var testVectors = [
-        ["", {
-            "v": "v1",
-            "hashes": {
-                "sha256": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU"
-            },
-            "key": {
-                "alg": "A256CTR",
-                "k": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "key_ops": ["encrypt", "decrypt"],
-                "kty": "oct"
-            },
-            "iv": "AAAAAAAAAAAAAAAAAAAAAA"
-        }, ""],
-        ["nZxRAVw962fwUQ5/", {
-            "v": "v1",
-            "hashes": {
-                "sha256": "geLWS2ptBew5aPLJRTK+QnI3Krdl3UaxN8qfahHWhfc"
-            }, "key": {
-                "alg": "A256CTR",
-                "k": "__________________________________________8",
-                "key_ops": ["encrypt", "decrypt"],
-                "kty": "oct"
-            }, "iv": "/////////////////////w"
-        }, "SGVsbG8sIFdvcmxk"],
-        ["tJVNBVJ/vl36UQt4Y5e5myqUL3M8OtjRVQljZ+LlwbJeucRIM7CeKDJGGOjlJ1bqpqUdl6zytXJ3dCyvnUi4eQ", {
-            "iv": "/////////////////////w",
-            "key": {
-                "kty": "oct",
-                "key_ops": [ "encrypt", "decrypt" ],
-                "k": "__________________________________________8",
-                "alg": "A256CTR"
-            },
-            "hashes": {
-                "sha256": "/K4w3G4zlLK312k66KxNPKDkWCn2QAH5aphAkuncTrQ"
-             }
-        }, "YWxwaGFudW1lcmljYWxseWFscGhhbnVtZXJpY2FsbHlhbHBoYW51bWVyaWNhbGx5YWxwaGFudW1lcmljYWxseQ"],
-        ["tJVNBVJ/vl36UQt4Y5e5m84bRUrQHhcdLPvS/7EkDvlkDLZXamBB6k8THbiawiKZ5Mnq9PZMSSbgOCvmnUBOMA", {
-            "v": "v1",
-            "hashes": {
-                "sha256": "LYG/orOViuFwovJpv2YMLSsmVKwLt7pY3f8SYM7KU5E"
-            },
-            "key": {
-                "kty": "oct",
-                "key_ops": ["encrypt","decrypt"],
-                "k": "__________________________________________8",
-                "alg": "A256CTR"
-            },
-            "iv": "/////////////////////w"
-        }, "YWxwaGFudW1lcmljYWxseWFscGhhbnVtZXJpY2FsbHlhbHBoYW51bWVyaWNhbGx5YWxwaGFudW1lcmljYWxseQ"]
-    ];
 
-    testVectors.forEach(function (vector) {
+var decryptTestVectors = [
+  [
+    "",
+    {
+      "iv": "AAAAAAAAAAAAAAAAAAAAAA",
+      "key": {
+        "kty": "oct",
+        "key_ops": [
+          "encrypt",
+          "decrypt"
+        ],
+        "k": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "alg": "A256CTR"
+      },
+      "v": "v2",
+      "hashes": {
+        "sha256": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU"
+      }
+    },
+    ""
+  ],
+  [
+    "5xJZTt5cQicm+9f4",
+    {
+      "iv": "//////////8AAAAAAAAAAA",
+      "key": {
+        "kty": "oct",
+        "key_ops": [
+          "encrypt",
+          "decrypt"
+        ],
+        "k": "__________________________________________8",
+        "alg": "A256CTR"
+      },
+      "v": "v2",
+      "hashes": {
+        "sha256": "YzF08lARDdOCzJpzuSwsjTNlQc4pHxpdHcXiD/wpK6k"
+      }
+    },
+    "SGVsbG8sIFdvcmxk"
+  ],
+  [
+    "zhtFStAeFx0s+9L/sSQO+WQMtldqYEHqTxMduJrCIpnkyer09kxJJuA4K+adQE4w+7jZe/vR9kIcqj9rOhDR8Q",
+    {
+      "iv": "//////////8AAAAAAAAAAA",
+      "key": {
+        "kty": "oct",
+        "key_ops": [
+          "encrypt",
+          "decrypt"
+        ],
+        "k": "__________________________________________8",
+        "alg": "A256CTR"
+      },
+      "v": "v2",
+      "hashes": {
+        "sha256": "IOq7/dHHB+mfHfxlRY5XMeCWEwTPmlf4cJcgrkf6fVU"
+      }
+    },
+    "YWxwaGFudW1lcmljYWxseWFscGhhbnVtZXJpY2FsbHlhbHBoYW51bWVyaWNhbGx5YWxwaGFudW1lcmljYWxseQ"
+  ],
+  [
+    "tJVNBVJ/vl36UQt4Y5e5m84bRUrQHhcdLPvS/7EkDvlkDLZXamBB6k8THbiawiKZ5Mnq9PZMSSbgOCvmnUBOMA",
+    {
+      "iv": "/////////////////////w",
+      "key": {
+        "kty": "oct",
+        "key_ops": [
+          "encrypt",
+          "decrypt"
+        ],
+        "k": "__________________________________________8",
+        "alg": "A256CTR"
+      },
+      "v": "v1",
+      "hashes": {
+        "sha256": "LYG/orOViuFwovJpv2YMLSsmVKwLt7pY3f8SYM7KU5E"
+      }
+    },
+    "YWxwaGFudW1lcmljYWxseWFscGhhbnVtZXJpY2FsbHlhbHBoYW51bWVyaWNhbGx5YWxwaGFudW1lcmljYWxseQ"
+  ],
+  [
+    "tJVNBVJ/vl36UQt4Y5e5myqUL3M8OtjRVQljZ+LlwbJeucRIM7CeKDJGGOjlJ1bqpqUdl6zytXJ3dCyvnUi4eQ",
+    {
+      "iv": "/////////////////////w",
+      "key": {
+        "kty": "oct",
+        "key_ops": [
+          "encrypt",
+          "decrypt"
+        ],
+        "k": "__________________________________________8",
+        "alg": "A256CTR"
+      },
+      "hashes": {
+        "sha256": "/K4w3G4zlLK312k66KxNPKDkWCn2QAH5aphAkuncTrQ"
+      }
+    },
+    "YWxwaGFudW1lcmljYWxseWFscGhhbnVtZXJpY2FsbHlhbHBoYW51bWVyaWNhbGx5YWxwaGFudW1lcmljYWxseQ"
+  ]
+];
+
+describe("DecryptAttachment", function() {
+
+    decryptTestVectors.forEach(function (vector) {
         var inputCiphertext = vector[0];
         var inputInfo = vector[1];
         var want = vector[2];

--- a/test/generate_test_vectors.py
+++ b/test/generate_test_vectors.py
@@ -54,7 +54,7 @@ def encrypt_ctr(key, iv, plaintext, counter_bits):
     return result
 
 
-def encrypt(key, iv, plaintext, bits=64):
+def encrypt(key, iv, plaintext, bits=64, version="v2"):
     ciphertext = encrypt_ctr(key, iv, plaintext, bits)
 
     info = {
@@ -67,13 +67,16 @@ def encrypt(key, iv, plaintext, bits=64):
         "iv": b64(iv),
         "hashes": { "sha256": b64(hashlib.sha256(ciphertext).digest()) }
     }
-    if bits == 64:
-        info["v"] = "v1"
+
+    if version:
+        info["v"] = version
+
     return b64(ciphertext), info, b64(plaintext)
 
 json.dump([
     encrypt("\x00"*32, "\x00"*16, ""),
-    encrypt("\xFF"*32, "\xFF"*16, "Hello, World"),
-    encrypt("\xFF"*32, "\xFF"*16, "alphanumerically" * 4, 128),
-    encrypt("\xFF"*32, "\xFF"*16, "alphanumerically" * 4),
+    encrypt("\xFF"*32, "\xFF"*8 + "\x00"*8, "Hello, World"),
+    encrypt("\xFF"*32, "\xFF"*8 + "\x00"*8, "alphanumerically" * 4),
+    encrypt("\xFF"*32, "\xFF"*16, "alphanumerically" * 4, 64, "v1"),
+    encrypt("\xFF"*32, "\xFF"*16, "alphanumerically" * 4, 128, None),
 ], sys.stdout)


### PR DESCRIPTION
This means that a file would have to be 2^68 bytes long before the
counter overflows. Since that is unlikely to happen most clients
can now get away without caring whether the overflow happens at 64 bits
or at 128 bits.

This makes it easier to support android and iOS where the default
implementations of AES-CTR overflow differently.